### PR TITLE
Audit: make deposit accounting safe

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -411,11 +411,11 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         Account storage account = accounts[token][to];
 
         uint256 actualAmount;
-        
+
         // Transfer tokens from sender to contract
         if (token == address(0)) {
             require(msg.value == amount, "must send an equal amount of native tokens");
-            actualAmount = amount; 
+            actualAmount = amount;
         } else {
             require(msg.value == 0, "must not send native tokens");
 
@@ -423,7 +423,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
             uint256 balanceBefore = IERC20(token).balanceOf(address(this));
             IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
             uint256 balanceAfter = IERC20(token).balanceOf(address(this));
-            
+
             actualAmount = balanceAfter - balanceBefore;
         }
 
@@ -468,14 +468,14 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         IERC20Permit(token).permit(to, address(this), amount, deadline, v, r, s);
 
         Account storage account = accounts[token][to];
-        
+
         // Use balance-before/balance-after accounting for fee-on-transfer tokens
         uint256 balanceBefore = IERC20(token).balanceOf(address(this));
         IERC20(token).safeTransferFrom(to, address(this), amount);
         uint256 balanceAfter = IERC20(token).balanceOf(address(this));
-        
+
         uint256 actualAmount = balanceAfter - balanceBefore;
-        
+
         account.funds += actualAmount;
 
         emit DepositRecorded(token, to, to, actualAmount, true);

--- a/test/FeeOnTransferVulnerability.t.sol
+++ b/test/FeeOnTransferVulnerability.t.sol
@@ -13,95 +13,88 @@ contract FeeOnTransferVulnerabilityTest is Test, BaseTestHelper {
     PaymentsTestHelpers helper;
     Payments payments;
     MockFeeOnTransferTokenWithPermit feeToken;
-    
+
     uint256 internal constant INITIAL_BALANCE = 10000 ether;
     uint256 internal constant DEPOSIT_AMOUNT = 1000 ether;
     uint256 internal constant FEE_PERCENTAGE = 200; // 2% fee
-    
+
     function setUp() public {
         // Create test helpers and setup environment
         helper = new PaymentsTestHelpers();
         helper.setupStandardTestEnvironment();
         payments = helper.payments();
-        
+
         // Create fee-on-transfer token with 2% fee
         feeToken = new MockFeeOnTransferTokenWithPermit("PermitFeeToken", "PFEE", FEE_PERCENTAGE);
-        
+
         // Mint tokens to users
         feeToken.mint(USER1, INITIAL_BALANCE);
         feeToken.mint(USER2, INITIAL_BALANCE);
-        
+
         // Approve payments contract
         vm.prank(USER1);
         feeToken.approve(address(payments), type(uint256).max);
-        
+
         vm.prank(USER2);
         feeToken.approve(address(payments), type(uint256).max);
     }
-    
+
     function testFeeOnTransferVulnerabilityBasic() public {
         // Record initial balances
         uint256 contractBalanceBefore = feeToken.balanceOf(address(payments));
-        
+
         // User1 deposits 1000 tokens, but due to 2% fee, only 980 actually reach the contract
         vm.prank(USER1);
         payments.deposit(address(feeToken), USER1, DEPOSIT_AMOUNT);
-        
+
         // Check actual token balance vs recorded balance
         uint256 contractBalanceAfter = feeToken.balanceOf(address(payments));
         uint256 actualTokensReceived = contractBalanceAfter - contractBalanceBefore;
         uint256 expectedTokensReceived = DEPOSIT_AMOUNT - (DEPOSIT_AMOUNT * FEE_PERCENTAGE / 10000);
-        
+
         // The contract actually received less due to fee
         assertEq(actualTokensReceived, expectedTokensReceived, "Contract received expected amount after fee");
         assertLt(actualTokensReceived, DEPOSIT_AMOUNT, "Contract received less than deposit amount");
-        
+
         // The payments contract also knows it does not have the full amount
-        (,uint256 recordedFunds,,) = payments.getAccountInfoIfSettled(address(feeToken), USER1);
+        (, uint256 recordedFunds,,) = payments.getAccountInfoIfSettled(address(feeToken), USER1);
         assertEq(recordedFunds, expectedTokensReceived, "Contract recorded full deposit amount");
     }
-    
+
     function testFeeOnTransferWithDepositWithPermit() public {
-        
         // Record initial balances
         uint256 contractBalanceBefore = feeToken.balanceOf(address(payments));
-        
+
         // Prepare permit parameters
         uint256 deadline = block.timestamp + 1 hours;
-        
+
         // Get permit signature
-        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
-            feeToken,
-            user1Sk,
-            USER1,
-            address(payments),
-            DEPOSIT_AMOUNT,
-            deadline
-        );
-        
+        (uint8 v, bytes32 r, bytes32 s) =
+            getPermitSignature(feeToken, user1Sk, USER1, address(payments), DEPOSIT_AMOUNT, deadline);
+
         // User1 deposits 1000 tokens using permit, but due to 2% fee, only 980 actually reach the contract
         vm.prank(USER1);
         payments.depositWithPermit(address(feeToken), USER1, DEPOSIT_AMOUNT, deadline, v, r, s);
-        
+
         // Check actual token balance vs recorded balance
         uint256 contractBalanceAfter = feeToken.balanceOf(address(payments));
         uint256 actualTokensReceived = contractBalanceAfter - contractBalanceBefore;
         uint256 expectedTokensReceived = DEPOSIT_AMOUNT - (DEPOSIT_AMOUNT * FEE_PERCENTAGE / 10000);
-        
+
         // The contract actually received less due to fee
         assertEq(actualTokensReceived, expectedTokensReceived, "Contract received expected amount after fee");
         assertLt(actualTokensReceived, DEPOSIT_AMOUNT, "Contract received less than deposit amount");
-        
+
         // With the fix, the payments contract should record the actual amount received
-        (,uint256 recordedFunds,,) = payments.getAccountInfoIfSettled(address(feeToken), USER1);
+        (, uint256 recordedFunds,,) = payments.getAccountInfoIfSettled(address(feeToken), USER1);
         assertEq(recordedFunds, expectedTokensReceived, "Contract recorded actual received amount");
-        
+
         console.log("Deposit amount:", DEPOSIT_AMOUNT);
         console.log("Actual tokens received:", actualTokensReceived);
         console.log("Recorded balance:", recordedFunds);
         console.log("Discrepancy:", recordedFunds > actualTokensReceived ? recordedFunds - actualTokensReceived : 0);
     }
-    
+
     function getPermitSignature(
         MockFeeOnTransferTokenWithPermit token,
         uint256 privateKey,
@@ -125,31 +118,24 @@ contract FeeOnTransferVulnerabilityTest is Test, BaseTestHelper {
         );
 
         bytes32 digest = MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash);
-        
+
         (v, r, s) = vm.sign(privateKey, digest);
     }
-    
+
     function testFeeOnTransferWithDepositWithPermitAndApproveOperator() public {
-        
         // Record initial balances
         uint256 contractBalanceBefore = feeToken.balanceOf(address(payments));
-        
+
         // Prepare permit and operator approval parameters
         uint256 deadline = block.timestamp + 1 hours;
         uint256 rateAllowance = 10 ether;
         uint256 lockupAllowance = 100 ether;
         uint256 maxLockupPeriod = 100;
-        
+
         // Get permit signature
-        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
-            feeToken,
-            user1Sk,
-            USER1,
-            address(payments),
-            DEPOSIT_AMOUNT,
-            deadline
-        );
-        
+        (uint8 v, bytes32 r, bytes32 s) =
+            getPermitSignature(feeToken, user1Sk, USER1, address(payments), DEPOSIT_AMOUNT, deadline);
+
         // User1 deposits 1000 tokens using permit and approves operator, but due to 2% fee, only 980 actually reach the contract
         vm.prank(USER1);
         payments.depositWithPermitAndApproveOperator(
@@ -165,28 +151,28 @@ contract FeeOnTransferVulnerabilityTest is Test, BaseTestHelper {
             lockupAllowance,
             maxLockupPeriod
         );
-        
+
         // Check actual token balance vs recorded balance
         uint256 contractBalanceAfter = feeToken.balanceOf(address(payments));
         uint256 actualTokensReceived = contractBalanceAfter - contractBalanceBefore;
         uint256 expectedTokensReceived = DEPOSIT_AMOUNT - (DEPOSIT_AMOUNT * FEE_PERCENTAGE / 10000);
-        
+
         // The contract actually received less due to fee
         assertEq(actualTokensReceived, expectedTokensReceived, "Contract received expected amount after fee");
         assertLt(actualTokensReceived, DEPOSIT_AMOUNT, "Contract received less than deposit amount");
-        
+
         // With the fix, the payments contract should record the actual amount received
-        (,uint256 recordedFunds,,) = payments.getAccountInfoIfSettled(address(feeToken), USER1);
+        (, uint256 recordedFunds,,) = payments.getAccountInfoIfSettled(address(feeToken), USER1);
         assertEq(recordedFunds, expectedTokensReceived, "Contract recorded actual received amount");
-        
+
         // Verify operator approval was set correctly
-        (bool isApproved, uint256 actualRateAllowance, uint256 actualLockupAllowance,,,uint256 actualMaxLockupPeriod) = 
+        (bool isApproved, uint256 actualRateAllowance, uint256 actualLockupAllowance,,, uint256 actualMaxLockupPeriod) =
             payments.operatorApprovals(address(feeToken), USER1, OPERATOR);
         assertEq(isApproved, true, "Operator should be approved");
         assertEq(actualRateAllowance, rateAllowance, "Rate allowance should be set");
         assertEq(actualLockupAllowance, lockupAllowance, "Lockup allowance should be set");
         assertEq(actualMaxLockupPeriod, maxLockupPeriod, "Max lockup period should be set");
-        
+
         console.log("Deposit amount:", DEPOSIT_AMOUNT);
         console.log("Actual tokens received:", actualTokensReceived);
         console.log("Recorded balance:", recordedFunds);

--- a/test/mocks/MockFeeOnTransferTokenWithPermit.sol
+++ b/test/mocks/MockFeeOnTransferTokenWithPermit.sol
@@ -5,40 +5,40 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
 contract MockFeeOnTransferTokenWithPermit is ERC20Permit {
     uint256 public feePercentage; // Fee in basis points (100 = 1%)
-    
-    constructor(string memory name, string memory symbol, uint256 _feePercentage) 
-        ERC20(name, symbol) 
-        ERC20Permit(name) 
+
+    constructor(string memory name, string memory symbol, uint256 _feePercentage)
+        ERC20(name, symbol)
+        ERC20Permit(name)
     {
         feePercentage = _feePercentage;
     }
-    
+
     function mint(address to, uint256 amount) public {
         _mint(to, amount);
     }
-    
+
     function setFeePercentage(uint256 _feePercentage) public {
         feePercentage = _feePercentage;
     }
-    
+
     function transfer(address to, uint256 amount) public override returns (bool) {
         return _transferWithFee(_msgSender(), to, amount);
     }
-    
+
     function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
         address spender = _msgSender();
         _spendAllowance(from, spender, amount);
         return _transferWithFee(from, to, amount);
     }
-    
+
     function _transferWithFee(address from, address to, uint256 amount) internal returns (bool) {
         uint256 fee = (amount * feePercentage) / 10000;
         uint256 actualAmount = amount - fee;
-        
+
         // Burn the fee (simulating fee-on-transfer)
         _transfer(from, address(0xdead), fee);
         _transfer(from, to, actualAmount);
-        
+
         return true;
     }
 }


### PR DESCRIPTION
Currently deposit accounting trusts that the ERC20 will transfer the entire amount from account to account.  While that is best practice and probably holds for usfdc it is not a guarantee and so before and after balance accounting is needed to prevent the payments contract from getting into a bad state where it thinks it has more tokens than it actually does.