### PR TITLE
feat(errors): add centralized custom error library for protocol

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ script = 'script'
 out = 'out'
 libs = ['lib']
 cache_path = 'cache'
-solc = "0.8.25"
+solc = "0.8.30"
 via_ir = true
 
 # For dependencies

--- a/src/ERC1967Proxy.sol
+++ b/src/ERC1967Proxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 /// @title Errors
 /// @notice Centralized library for custom error definitions across the protocol

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 library RateChangeQueue {
     struct RateChange {

--- a/test/AccountLockupSettlement.t.sol
+++ b/test/AccountLockupSettlement.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/AccountManagement.t.sol
+++ b/test/AccountManagement.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/DepositWithPermitAndOperatorApproval.t.sol
+++ b/test/DepositWithPermitAndOperatorApproval.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/ERC1967Proxy.t.sol
+++ b/test/ERC1967Proxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/FeeOnTransferVulnerability.t.sol
+++ b/test/FeeOnTransferVulnerability.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test, console} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/Fees.t.sol
+++ b/test/Fees.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/OperatorApproval.t.sol
+++ b/test/OperatorApproval.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/OperatorApprovalUsageLeak.t.sol
+++ b/test/OperatorApprovalUsageLeak.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/PayeeFaultArbitrationBug.t.sol
+++ b/test/PayeeFaultArbitrationBug.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/PaymentsAccessControl.t.sol
+++ b/test/PaymentsAccessControl.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/PaymentsEvents.t.sol
+++ b/test/PaymentsEvents.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test, Vm} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/RailGetters.t.sol
+++ b/test/RailGetters.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../src/Payments.sol";

--- a/test/RateChangeQueue.t.sol
+++ b/test/RateChangeQueue.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {RateChangeQueue} from "../src/RateChangeQueue.sol";

--- a/test/helpers/BaseTestHelper.sol
+++ b/test/helpers/BaseTestHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../../src/Payments.sol";

--- a/test/helpers/RailSettlementHelpers.sol
+++ b/test/helpers/RailSettlementHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 import {Payments} from "../../src/Payments.sol";

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 

--- a/test/mocks/MockFeeOnTransferTokenWithPermit.sol
+++ b/test/mocks/MockFeeOnTransferTokenWithPermit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.27;
 
 import {Payments, IValidator} from "../../src/Payments.sol";
 


### PR DESCRIPTION
## Summary

This PR refactors the Payments contract and its test suite to use a centralized custom error library (`Errors.sol`) instead of string-based revert messages.

## Key changes

- Adds a protocol-level `Errors.sol` with descriptive custom errors for core revert scenarios.
- Refactors most `require` and `revert` statements in `Payments.sol` to use custom errors
- Updates test suite to check for revert selectors and error parameters rather than error strings.

## Results

| Metric                  | Before (Strings) | After (Custom Errors) | Change       |
|-------------------------|------------------|-----------------------|--------------|
| Deployment Size (bytes) | 22,118           | 19,553                | **-2,565**   |
| Deployment Cost (gas)   | 4,838,144        | 4,284,257             | **-553,887** |

_These results are **without** the optimizer turned on. I'll share the optimized results later._

Closes #156 