### PR TITLE
feat: add permit recipient validation and corresponding error handling

### DIFF
--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -285,4 +285,9 @@ library Errors {
     /// @param required The minimum required native token amount
     /// @param sent The amount of native token sent with the transaction
     error InsufficientNativeTokenForBurn(uint256 required, uint256 sent);
+
+    /// @notice The 'to' address in permit functions must be the message sender
+    /// @param expected The expected address (msg.sender)
+    /// @param actual The actual 'to' address provided
+    error PermitRecipientMustBeMsgSender(address expected, address actual);
 }

--- a/test/AccountManagement.t.sol
+++ b/test/AccountManagement.t.sol
@@ -50,7 +50,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
     }
 
     function testDepositWithPermitExpiredPermitReverts() public {
-        helper.expectExpiredPermitToRevert(user1Sk, USER2, DEPOSIT_AMOUNT);
+        helper.expectExpiredPermitToRevert(user1Sk, USER1, DEPOSIT_AMOUNT);
     }
 
     function testDepositWithPermitZeroAmountNoEffect() public {
@@ -68,6 +68,10 @@ contract AccountManagementTest is Test, BaseTestHelper {
 
     function testDepositWithPermitInvalidPermitReverts() public {
         helper.expectInvalidPermitToRevert(user1Sk, USER1, DEPOSIT_AMOUNT);
+    }
+
+    function testDepositWithPermitToAnotherUserReverts() public {
+        helper.expectDepositWithPermitToAnotherUserToRevert(user1Sk, USER2, DEPOSIT_AMOUNT);
     }
 
     function testNativeDepositWithInsufficientNativeTokens() public {

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -851,4 +851,18 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
 
         verifyOperatorAllowances(from, operator, false, 0, 0, 0, 0, 0); // No values should have been set due to revert - expect defaults
     }
+
+    function expectDepositWithPermitToAnotherUserToRevert(uint256 senderSk, address to, uint256 amount) public {
+        address from = vm.addr(senderSk);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Get permit signature for the sender
+        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(senderSk, from, address(payments), amount, deadline);
+
+        // Expect revert when trying to deposit to a different address than msg.sender
+        vm.startPrank(from);
+        vm.expectRevert(abi.encodeWithSelector(Errors.PermitRecipientMustBeMsgSender.selector, from, to));
+        payments.depositWithPermit(address(testToken), to, amount, deadline, v, r, s);
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
This pull request introduces a validation mechanism to ensure that the recipient (`to`) address in permit-based functions matches the `msg.sender`. It includes updates to the `Payments` contract, new error definitions, and corresponding test cases to enforce and verify this behavior.

### Core Validation Updates:

* **Error Definition:** Added a new error `PermitRecipientMustBeMsgSender` in `Errors.sol` to handle cases where the recipient address does not match the message sender.
* **Modifier Addition:** Introduced the `validatePermitRecipient` modifier in `Payments.sol` to enforce the recipient validation in relevant functions.

### Function Enhancements:

* **Deposit with Permit:** Updated the `depositWithPermit` function in `Payments.sol` to include the `validatePermitRecipient` modifier, ensuring the recipient address matches `msg.sender`.
* **Operator Approval:** Modified the `_setOperatorApproval` function to incorporate the `validatePermitRecipient` modifier for consistency in recipient validation.

### Test Case Additions:

* **New Tests:** Added `testDepositWithPermitToAnotherUserReverts` in `AccountManagement.t.sol` and `expectDepositWithPermitToAnotherUserToRevert` in `PaymentsTestHelpers.sol` to verify that the validation mechanism correctly reverts transactions with mismatched recipient addresses. [[1]](diffhunk://#diff-98fc45b4c216e40d8916ee0b0e28adde98ff1a56b25803e1fedbef8917b290afR73-R76) [[2]](diffhunk://#diff-88114fe04c915cbf4c5afc6f6fd7fd4239f1441e161788810102ec036575703bR854-R867)