### PR TITLE
feat: callback for rail termination

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -32,12 +32,7 @@ interface IValidator {
         uint256 rate
     ) external returns (ValidationResult memory result);
 
-
-    function railTerminated(
-        uint256 railId,
-        address terminator,
-        uint256 endEpoch
-    ) external;
+    function railTerminated(uint256 railId, address terminator, uint256 endEpoch) external;
 }
 
 // @title Payments contract.

--- a/test/PayeeFaultArbitrationBug.t.sol
+++ b/test/PayeeFaultArbitrationBug.t.sol
@@ -56,7 +56,7 @@ contract PayeeFaultArbitrationBugTest is Test, BaseTestHelper {
         assertTrue(validator.railTerminatedCalled(), "railTerminated should have been called");
         assertEq(validator.lastTerminatedRailId(), railId, "Incorrect railId passed to validator");
         assertEq(validator.lastTerminator(), OPERATOR, "Incorrect terminator passed to validator");
-        
+
         // Get the rail to verify the endEpoch matches
         Payments.RailView memory rail = payments.getRail(railId);
         assertEq(validator.lastEndEpoch(), rail.endEpoch, "Incorrect endEpoch passed to validator");

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -92,11 +92,7 @@ contract MockValidator is IValidator {
         }
     }
 
-    function railTerminated(
-        uint256 railId,
-        address terminator,
-        uint256 endEpoch
-    ) external override {
+    function railTerminated(uint256 railId, address terminator, uint256 endEpoch) external override {
         lastTerminatedRailId = railId;
         lastTerminator = terminator;
         lastEndEpoch = endEpoch;


### PR DESCRIPTION
This makes it easy for service contracts to discover rail termination.