### PR TITLE
Block Timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ Payment settlement can be triggered by any rail participant:
 // Settlement call - can be made by client, service provider, or operator
 (uint256 amount, uint256 settledEpoch, string memory note) = Payments(paymentsContractAddress).settleRail(
     railId,        // Rail ID
-    block.number   // Settle up to current epoch
+    block.timestamp   // Settle up to now
 );
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -251,7 +251,7 @@ Rate changes to a rail are the most complex.  They require adding a segment to t
 
 All three modifications change the total amount of `lockupCurrent` in the payer's account.  These changes are made over the payer's account under the assumption that they have enough available balance which is then checked in the post condition modifier.
 
-Only live fully settled accounts without any debt, i.e. with `lockupLastSettledAt == block.number`, are allowed to increase `fixedLockup`, make any changes to the `lockupPeriod` or increase to the rail's `paymentRate`. Terminated and debtor rails *are* allowed to *reduce* their `fixedLockup`.  And terminated rails are allowed to decrease the rail's payment rate (debtors can't make any changes).
+Only live fully settled accounts without any debt, i.e. with `lockupLastSettledAt == block.timestamp`, are allowed to increase `fixedLockup`, make any changes to the `lockupPeriod` or increase to the rail's `paymentRate`. Terminated and debtor rails *are* allowed to *reduce* their `fixedLockup`.  And terminated rails are allowed to decrease the rail's payment rate (debtors can't make any changes).
 
 For all three changes the operator approval must be consulted to check that the proposed modifications are within the operator's remaining allowances.  It is worth noting that the operator approval has a field `maxLockupPeriod` which sets a ceiling on the lockup period and hence streaming lockup.
 

--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -148,8 +148,8 @@ library Errors {
     /// @notice Cannot modify a terminated rail beyond its end epoch
     /// @param railId The ID of the rail
     /// @param maxSettlementEpoch The last allowed block for modifications
-    /// @param blockNumber The current block number
-    error CannotModifyTerminatedRailBeyondEndEpoch(uint256 railId, uint256 maxSettlementEpoch, uint256 blockNumber);
+    /// @param blockTimestamp The current block timestamp
+    error CannotModifyTerminatedRailBeyondEndEpoch(uint256 railId, uint256 maxSettlementEpoch, uint256 blockTimestamp);
 
     /// @notice Cannot increase the payment rate or change the rate on a terminated rail
     /// @param railId The ID of the rail
@@ -181,12 +181,12 @@ library Errors {
 
     /// @notice Cannot settle a terminated rail without validation until after the max settlement epoch has passed
     /// @param railId The ID of the rail being settled
-    /// @param currentBlock The current block number (actual)
+    /// @param currentBlock The current block timestamp (actual)
     /// @param requiredBlock The max settlement epoch block (expected, must be exceeded)
     error CannotSettleTerminatedRailBeforeMaxEpoch(
         uint256 railId,
         uint256 requiredBlock, // expected (maxSettleEpoch + 1)
-        uint256 currentBlock // actual (block.number)
+        uint256 currentBlock // actual (block.timestamp)
     );
 
     /// @notice Cannot settle a rail for epochs in the future.

--- a/test/AccountLockupSettlement.t.sol
+++ b/test/AccountLockupSettlement.t.sol
@@ -37,13 +37,13 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
         // No rails created, so lockup rate should be 0
 
         // Advance blocks to create a settlement gap without a rate
-        helper.advanceBlocks(10);
+        helper.advanceTime(10);
 
         // Trigger settlement with a new deposit
         helper.makeDeposit(USER1, USER1, DEPOSIT_AMOUNT);
 
         // Verify settlement occurred
-        helper.assertAccountState(USER1, DEPOSIT_AMOUNT * 2, 0, 0, block.number);
+        helper.assertAccountState(USER1, DEPOSIT_AMOUNT * 2, 0, 0, block.timestamp);
     }
 
     function testSimpleLockupAccumulation() public {
@@ -70,7 +70,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
         // Note: Settlement begins at the current block
         // Advance blocks to create a settlement gap
         uint256 elapsedBlocks = 5;
-        helper.advanceBlocks(elapsedBlocks);
+        helper.advanceTime(elapsedBlocks);
 
         // Trigger settlement with a new deposit
         helper.makeDeposit(USER1, USER1, DEPOSIT_AMOUNT);
@@ -81,7 +81,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
         uint256 expectedLockup = initialLockup + accumulatedLockup;
 
         // Verify settlement occurred
-        helper.assertAccountState(USER1, DEPOSIT_AMOUNT * 2, expectedLockup, lockupRate, block.number);
+        helper.assertAccountState(USER1, DEPOSIT_AMOUNT * 2, expectedLockup, lockupRate, block.timestamp);
     }
 
     function testPartialSettlement() public {
@@ -111,7 +111,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
 
         // Advance many blocks to exceed available funds
         uint256 advancedBlocks = 10;
-        helper.advanceBlocks(advancedBlocks);
+        helper.advanceTime(advancedBlocks);
 
         // Deposit additional funds, which will trigger settlement
         helper.makeDeposit(USER1, USER1, DEPOSIT_AMOUNT / 2);
@@ -154,7 +154,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
         );
 
         // Roll forward many blocks
-        helper.advanceBlocks(30);
+        helper.advanceTime(30);
 
         // Trigger settlement with a new deposit
         helper.makeDeposit(USER1, USER1, DEPOSIT_AMOUNT);
@@ -168,7 +168,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT * 3, // expected funds
             expectedLockup, // expected lockup
             lockupRate, // expected lockup rate
-            block.number // expected settlement block
+            block.timestamp // expected settlement block
         );
     }
 
@@ -198,7 +198,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT,
             DEPOSIT_AMOUNT,
             0, // no payment rate
-            block.number
+            block.timestamp
         );
 
         helper.makeDeposit(USER1, USER1, 1); // Adding more funds
@@ -273,7 +273,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             60 ether, // expected funds
             60 ether, // expected lockup
             lockupRate, // expected lockup rate
-            block.number // expected settlement block
+            block.timestamp // expected settlement block
         );
     }
 }

--- a/test/AccountManagement.t.sol
+++ b/test/AccountManagement.t.sol
@@ -212,7 +212,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT, // expected funds
             lockedAmount, // expected lockup
             0, // expected rate (not set in this test)
-            block.number // expected last settled
+            block.timestamp // expected last settled
         );
 
         // Try to withdraw more than unlocked funds
@@ -263,7 +263,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         );
 
         // Advance 10 blocks to create settlement gap
-        helper.advanceBlocks(10);
+        helper.advanceTime(10);
 
         // Make another deposit to trigger settlement
         helper.makeDeposit(USER1, USER1, DEPOSIT_AMOUNT);
@@ -274,7 +274,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT * 2, // expected funds
             20 ether, // expected lockup (2 rails × 0.5 ether per block × 10 blocks + future lockup of 10 ether)
             lockupRate * 2, // expected rate (2 * 0.5 ether)
-            block.number // expected last settled
+            block.timestamp // expected last settled
         );
     }
 
@@ -335,7 +335,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         uint256 lockupRate,
         uint256 lockupLastSettledAt
     ) internal view returns (uint256 simulatedLockupCurrent, uint256 availableBalance) {
-        uint256 currentEpoch = block.number;
+        uint256 currentEpoch = block.timestamp;
         uint256 elapsedTime = currentEpoch - lockupLastSettledAt;
         simulatedLockupCurrent = lockupCurrent;
 
@@ -379,7 +379,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         );
 
         // Advance 5 blocks
-        helper.advanceBlocks(5);
+        helper.advanceTime(5);
 
         // Get raw account data for debugging
         (uint256 funds, uint256 lockupCurrent, uint256 lockupRate2, uint256 lockupLastSettledAt) =
@@ -396,7 +396,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         assertEq(totalBalance1, DEPOSIT_AMOUNT, "total balance mismatch");
         assertEq(availableBalance1, availableBalance, "available balance mismatch");
         assertEq(lockupRate1, lockupRate, "lockup rate mismatch");
-        assertEq(fundedUntil, block.number + (availableBalance / lockupRate), "funded until mismatch");
+        assertEq(fundedUntil, block.timestamp + (availableBalance / lockupRate), "funded until mismatch");
     }
 
     function testGetAccountInfoWithPartialSettlement() public {
@@ -422,7 +422,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         );
 
         // Advance blocks to create partial settlement
-        helper.advanceBlocks(5);
+        helper.advanceTime(5);
 
         // Get raw account data for debugging
         (uint256 funds, uint256 lockupCurrent, uint256 lockupRate2, uint256 lockupLastSettledAt) =
@@ -439,7 +439,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         assertEq(totalBalance2, DEPOSIT_AMOUNT, "total balance mismatch");
         assertEq(availableBalance2, availableBalance, "available balance mismatch");
         assertEq(lockupRate3, lockupRate, "lockup rate mismatch");
-        assertEq(fundedUntil, block.number + (availableBalance / lockupRate), "funded until mismatch");
+        assertEq(fundedUntil, block.timestamp + (availableBalance / lockupRate), "funded until mismatch");
     }
 
     function testGetAccountInfoInDebt() public {
@@ -465,7 +465,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         );
 
         // Advance blocks to create debt
-        helper.advanceBlocks(60); // This will create debt as 60 * 2 > DEPOSIT_AMOUNT
+        helper.advanceTime(60); // This will create debt as 60 * 2 > DEPOSIT_AMOUNT
 
         // Get account info
         (uint256 fundedUntil, uint256 totalBalance3, uint256 availableBalance3, uint256 lockupRate3) =
@@ -475,7 +475,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         assertEq(totalBalance3, DEPOSIT_AMOUNT, "total balance mismatch");
         assertEq(availableBalance3, 0, "available balance should be 0");
         assertEq(lockupRate3, lockupRate, "lockup rate mismatch");
-        assertTrue(fundedUntil < block.number, "funded until should be in the past");
+        assertTrue(fundedUntil < block.timestamp, "funded until should be in the past");
     }
 
     function testGetAccountInfoAfterRateChange() public {
@@ -501,7 +501,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
         );
 
         // Advance some blocks
-        helper.advanceBlocks(5);
+        helper.advanceTime(5);
 
         // Change the rate
         uint256 newRate = 2 ether; // 2 tokens per block
@@ -523,6 +523,6 @@ contract AccountManagementTest is Test, BaseTestHelper {
         assertEq(totalBalance4, DEPOSIT_AMOUNT, "total balance mismatch");
         assertEq(availableBalance4, availableBalance, "available balance mismatch");
         assertEq(lockupRate4, newRate, "lockup rate mismatch");
-        assertEq(fundedUntil, block.number + (availableBalance / newRate), "funded until mismatch");
+        assertEq(fundedUntil, block.timestamp + (availableBalance / newRate), "funded until mismatch");
     }
 }

--- a/test/Fees.t.sol
+++ b/test/Fees.t.sol
@@ -155,24 +155,24 @@ contract FeesTest is Test, BaseTestHelper {
 
     function testNetworkFee() public {
         uint256 networkFee = payments.NETWORK_FEE();
-        helper.advanceBlocks(5);
+        helper.advanceTime(5);
 
         uint256 startBalance = USER1.balance;
         vm.prank(USER1);
         vm.expectRevert(
             abi.encodeWithSelector(Errors.InsufficientNativeTokenForBurn.selector, networkFee, networkFee - 1)
         );
-        payments.settleRail{value: networkFee - 1}(rail1Id, block.number);
+        payments.settleRail{value: networkFee - 1}(rail1Id, block.timestamp);
         assertEq(startBalance, USER1.balance, "no fee should be taken on revert");
 
         startBalance = USER1.balance;
         vm.prank(USER1);
-        payments.settleRail{value: networkFee}(rail2Id, block.number);
+        payments.settleRail{value: networkFee}(rail2Id, block.timestamp);
         assertEq(startBalance - networkFee, USER1.balance, "fee should be taken on success");
 
         startBalance = USER1.balance;
         vm.prank(USER1);
-        payments.settleRail{value: networkFee + 100}(rail3Id, block.number);
+        payments.settleRail{value: networkFee + 100}(rail3Id, block.timestamp);
         assertEq(startBalance - networkFee, USER1.balance, "extra amount is returned");
     }
 }

--- a/test/OperatorApprovalUsageLeak.t.sol
+++ b/test/OperatorApprovalUsageLeak.t.sol
@@ -71,15 +71,15 @@ contract OperatorApprovalUsageLeakTest is Test, BaseTestHelper {
         uint256 endEpoch = lockupLastSettledAt + lockupPeriod;
 
         console.log("\nAfter termination:");
-        console.log("  Current block:", block.number);
+        console.log("  Current block:", block.timestamp);
         console.log("  Lockup last settled at:", lockupLastSettledAt);
         console.log("  Rail end epoch:", endEpoch);
 
         // Move time forward to after the rail's end epoch
-        vm.roll(endEpoch + 1);
+        vm.warp(endEpoch + 1);
 
         console.log("\nAfter time advance:");
-        console.log("  Current block:", block.number);
+        console.log("  Current block:", block.timestamp);
 
         // Settle the rail completely - this will trigger finalizeTerminatedRail
         vm.startPrank(USER2); // Payee can settle
@@ -137,7 +137,7 @@ contract OperatorApprovalUsageLeakTest is Test, BaseTestHelper {
             uint256 endEpoch = lockupLastSettledAt + lockupPeriod;
 
             // Move time forward
-            vm.roll(endEpoch + 1);
+            vm.warp(endEpoch + 1);
 
             // Settle to trigger finalization
             vm.startPrank(USER2);

--- a/test/PayeeFaultArbitrationBug.t.sol
+++ b/test/PayeeFaultArbitrationBug.t.sol
@@ -61,10 +61,10 @@ contract PayeeFaultArbitrationBugTest is Test, BaseTestHelper {
         Payments.RailView memory rail = payments.getRail(railId);
         assertEq(validator.lastEndEpoch(), rail.endEpoch, "Incorrect endEpoch passed to validator");
 
-        helper.advanceBlocks(15);
+        helper.advanceTime(15);
 
         vm.prank(USER1);
-        payments.settleRail{value: networkFee}(railId, block.number);
+        payments.settleRail{value: networkFee}(railId, block.timestamp);
 
         Payments.Account memory payerFinal = helper.getAccountData(USER1);
 
@@ -92,10 +92,10 @@ contract PayeeFaultArbitrationBugTest is Test, BaseTestHelper {
         console.log("Expected total lockup:", expectedTotalLockup);
 
         vm.prank(OPERATOR);
-        helper.advanceBlocks(15);
+        helper.advanceTime(15);
 
         vm.prank(USER1);
-        payments.settleRail{value: networkFee}(railId, block.number);
+        payments.settleRail{value: networkFee}(railId, block.timestamp);
 
         Payments.Account memory payerFinal = helper.getAccountData(USER1);
 
@@ -128,10 +128,10 @@ contract PayeeFaultArbitrationBugTest is Test, BaseTestHelper {
         console.log("Expected total lockup:", expectedTotalLockup);
 
         vm.prank(OPERATOR);
-        helper.advanceBlocks(15);
+        helper.advanceTime(15);
 
         vm.prank(USER1);
-        payments.settleRail{value: networkFee}(railId, block.number);
+        payments.settleRail{value: networkFee}(railId, block.timestamp);
 
         Payments.Account memory payerFinal = helper.getAccountData(USER1);
 

--- a/test/PaymentsAccessControl.t.sol
+++ b/test/PaymentsAccessControl.t.sol
@@ -149,7 +149,7 @@ contract AccessControlTest is Test, BaseTestHelper {
 
     function testTerminateRail_OnlyOperatorCanTerminateWhenLockupNotFullySettled() public {
         // Advance blocks to create an unsettled state
-        helper.advanceBlocks(500);
+        helper.advanceTime(500);
 
         // Client should not be able to terminate because lockup is not fully settled
         vm.startPrank(USER1);

--- a/test/PaymentsEvents.t.sol
+++ b/test/PaymentsEvents.t.sol
@@ -59,14 +59,14 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
 
         vm.stopPrank();
 
-        helper.advanceBlocks(5);
+        helper.advanceTime(5);
 
         vm.startPrank(OPERATOR);
 
         // Expect the event to be emitted
         // lockupCurrent = 25 ether ( from modifyRailPayment ) + 5 * 5 ether ( elapsedTime * lockupRate)
         vm.expectEmit(true, true, true, true);
-        emit Payments.AccountLockupSettled(address(testToken), USER1, 50 ether, 5 ether, block.number);
+        emit Payments.AccountLockupSettled(address(testToken), USER1, 50 ether, 5 ether, block.timestamp);
         emit Payments.RailLockupModified(railId, 5, 10, 0, 0);
 
         payments.modifyRailLockup(railId, 10, 0 ether);
@@ -212,7 +212,7 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // Advance blocks to accumulate payment
-        helper.advanceBlocks(5);
+        helper.advanceTime(5);
 
         vm.startPrank(USER1);
 
@@ -225,11 +225,11 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
         // Expect the event to be emitted
         vm.expectEmit(true, true, false, true);
         emit Payments.RailSettled(
-            railId, totalSettledAmount, totalNetPayeeAmount, totalOperatorCommission, block.number
+            railId, totalSettledAmount, totalNetPayeeAmount, totalOperatorCommission, block.timestamp
         );
 
         // Settle rail
-        payments.settleRail{value: networkFee}(railId, block.number);
+        payments.settleRail{value: networkFee}(railId, block.timestamp);
 
         vm.stopPrank();
     }
@@ -250,7 +250,7 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
 
         // expected end epoch
         Payments.RailView memory rail = payments.getRail(railId);
-        uint256 expectedEndEpoch = block.number + rail.lockupPeriod;
+        uint256 expectedEndEpoch = block.timestamp + rail.lockupPeriod;
         // Expect the event to be emitted
         vm.expectEmit(true, true, false, true);
         emit Payments.RailTerminated(railId, USER1, expectedEndEpoch);
@@ -282,7 +282,7 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
         Payments.RailView memory rail = payments.getRail(railId);
 
         // Advance blocks past the end epoch
-        helper.advanceBlocks(rail.lockupPeriod + 1);
+        helper.advanceTime(rail.lockupPeriod + 1);
 
         vm.startPrank(USER1);
 
@@ -308,7 +308,7 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
         // Expect the event to be emitted
         // Only check the first three indexed parameters
         vm.expectEmit(true, true, true, true);
-        emit Payments.AccountLockupSettled(address(testToken), USER2, 0, 0, block.number);
+        emit Payments.AccountLockupSettled(address(testToken), USER2, 0, 0, block.timestamp);
         emit Payments.DepositRecorded(address(testToken), USER1, USER2, 10 ether, false); // Amount not checked
 
         // Deposit tokens
@@ -335,7 +335,7 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
 
         // Expect the event to be emitted
         vm.expectEmit(true, true, false, true);
-        emit Payments.AccountLockupSettled(address(testToken), signer, 0, 0, block.number);
+        emit Payments.AccountLockupSettled(address(testToken), signer, 0, 0, block.timestamp);
         emit Payments.DepositRecorded(address(testToken), signer, signer, depositAmount, true);
 
         // Deposit with permit

--- a/test/RailGetters.t.sol
+++ b/test/RailGetters.t.sol
@@ -263,8 +263,8 @@ contract PayeeRailsTest is Test, BaseTestHelper {
         }
 
         // Advance blocks beyond the end epoch of Rail 3
-        uint256 blocksToAdvance = endEpoch - block.number + 1;
-        helper.advanceBlocks(blocksToAdvance);
+        uint256 blocksToAdvance = endEpoch - block.timestamp + 1;
+        helper.advanceTime(blocksToAdvance);
 
         // IMPORTANT: Settle the rail now that we're beyond its end epoch
         // This will finalize the rail (set rail.from = address(0))

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -511,8 +511,8 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         );
     }
 
-    function advanceBlocks(uint256 blocks) public {
-        vm.roll(block.number + blocks);
+    function advanceTime(uint256 time) public {
+        vm.warp(block.timestamp + time);
     }
 
     function assertAccountState(

--- a/test/helpers/RailSettlementHelpers.sol
+++ b/test/helpers/RailSettlementHelpers.sol
@@ -80,7 +80,7 @@ contract RailSettlementHelpers is Test {
             payments.modifyRailPayment(railId, rates[i], 0);
 
             // Advance one block to ensure the changes are at different epochs
-            baseHelper.advanceBlocks(1);
+            baseHelper.advanceTime(1);
         }
         vm.stopPrank();
 
@@ -105,7 +105,7 @@ contract RailSettlementHelpers is Test {
         );
 
         // Advance blocks past the lockup period to force the rail into debt
-        baseHelper.advanceBlocks(lockupPeriod + 1);
+        baseHelper.advanceTime(lockupPeriod + 1);
 
         return railId;
     }
@@ -201,7 +201,7 @@ contract RailSettlementHelpers is Test {
             "Rail end epoch should be account lockup last settled at + rail lockup period"
         );
 
-        return settleRailAndVerify(railId, block.number, expectedAmount, expectedUpto);
+        return settleRailAndVerify(railId, block.timestamp, expectedAmount, expectedUpto);
     }
 
     function modifyRailSettingsAndVerify(


### PR DESCRIPTION

Reviewer @ZenGround0 @rvagg
The time between blocks might change in the future.
This should not impact the duration of agreements or the payment rate over time.
#### Changes
* replace block.number with block.timestamp
* TODO rename epoch