### PR TITLE
feat: add support for ERC-3009

### DIFF
--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -286,8 +286,9 @@ library Errors {
     /// @param sent The amount of native token sent with the transaction
     error InsufficientNativeTokenForBurn(uint256 required, uint256 sent);
 
-    /// @notice The 'to' address in permit functions must be the message sender
+    /// @notice The 'to' address must equal the transaction sender (self-recipient enforcement)
+    /// @dev Used by flows like permit and transfer-with-authorization to ensure only self-deposits
     /// @param expected The expected address (msg.sender)
     /// @param actual The actual 'to' address provided
-    error PermitRecipientMustBeMsgSender(address expected, address actual);
+    error SignerMustBeMsgSender(address expected, address actual);
 }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -57,6 +57,8 @@ interface IERC3009 {
         bytes32 r,
         bytes32 s
     ) external;
+
+    function authorizationState(address user, bytes32 nonce) external view returns (bool used);
 }
 
 // @title Payments contract.
@@ -262,8 +264,8 @@ contract Payments is ReentrancyGuard {
         _;
     }
 
-    modifier validatePermitRecipient(address to) {
-        require(to == msg.sender, Errors.PermitRecipientMustBeMsgSender(msg.sender, to));
+    modifier validateSignerIsRecipient(address to) {
+        require(to == msg.sender, Errors.SignerMustBeMsgSender(msg.sender, to));
         _;
     }
 
@@ -535,7 +537,7 @@ contract Payments is ReentrancyGuard {
         external
         nonReentrant
         validateNonZeroAddress(to, "to")
-        validatePermitRecipient(to)
+        validateSignerIsRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _depositWithPermit(token, to, amount, deadline, v, r, s);
@@ -606,7 +608,7 @@ contract Payments is ReentrancyGuard {
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
-        validatePermitRecipient(to)
+        validateSignerIsRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _setOperatorApproval(token, operator, true, rateAllowance, lockupAllowance, maxLockupPeriod);
@@ -643,7 +645,7 @@ contract Payments is ReentrancyGuard {
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
-        validatePermitRecipient(to)
+        validateSignerIsRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _increaseOperatorApproval(token, operator, rateAllowanceIncrease, lockupAllowanceIncrease);
@@ -654,7 +656,6 @@ contract Payments is ReentrancyGuard {
      * @notice Deposits tokens using an ERC-3009 authorization in a single transaction.
      * @dev This allows a third party to submit a pre-signed transfer authorization to deposit tokens on behalf of a user.
      * @param token The ERC-20 token address to deposit. Must conform to ERC-3009.
-     * @param from The address authorizing the transfer (the owner of the funds).
      * @param to The address whose account within the contract will be credited.
      * @param amount The amount of tokens to deposit.
      * @param validAfter The timestamp after which the authorization is valid.
@@ -664,7 +665,6 @@ contract Payments is ReentrancyGuard {
      */
     function depositWithAuthorization(
         address token,
-        address from,
         address to,
         uint256 amount,
         uint256 validAfter,
@@ -676,16 +676,15 @@ contract Payments is ReentrancyGuard {
     )
         external
         nonReentrant
-        validateNonZeroAddress(from, "from")
         validateNonZeroAddress(to, "to")
+        validateSignerIsRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
-        _depositWithAuthorization(token, from, to, amount, validAfter, validBefore, nonce, v, r, s);
+        _depositWithAuthorization(token, to, amount, validAfter, validBefore, nonce, v, r, s);
     }
 
     function _depositWithAuthorization(
         address token,
-        address from,
         address to,
         uint256 amount,
         uint256 validAfter,
@@ -702,9 +701,9 @@ contract Payments is ReentrancyGuard {
         uint256 balanceBefore = IERC20(token).balanceOf(address(this));
 
         // Call ERC-3009 transferWithAuthorization.
-        // This will transfer 'amount' from 'from' to this contract.
+        // This will transfer 'amount' from 'to' to this contract.
         // The token contract itself verifies the signature.
-        IERC3009(token).transferWithAuthorization(from, address(this), amount, validAfter, validBefore, nonce, v, r, s);
+        IERC3009(token).transferWithAuthorization(to, address(this), amount, validAfter, validBefore, nonce, v, r, s);
 
         uint256 balanceAfter = IERC20(token).balanceOf(address(this));
         uint256 actualAmount = balanceAfter - balanceBefore;
@@ -714,7 +713,7 @@ contract Payments is ReentrancyGuard {
         account.funds += actualAmount;
 
         // Emit an event to record the deposit, marking it as made via an off-chain signature.
-        emit DepositRecorded(token, from, to, actualAmount, AuthType.Authorization, nonce);
+        emit DepositRecorded(token, to, to, actualAmount, AuthType.Authorization, nonce);
     }
 
     /// @notice Withdraws tokens from the caller's account to the caller's account, up to the amount of currently available tokens (the tokens not currently locked in rails).

--- a/test/DepositWithAuthorization.t.sol
+++ b/test/DepositWithAuthorization.t.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Payments, IERC3009} from "../src/Payments.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {PaymentsTestHelpers} from "./helpers/PaymentsTestHelpers.sol";
+import {BaseTestHelper} from "./helpers/BaseTestHelper.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {console} from "forge-std/console.sol";
+import {Errors} from "../src/Errors.sol";
+
+contract DepositWithAuthorization is Test, BaseTestHelper {
+    MockERC20 testToken;
+    PaymentsTestHelpers helper;
+    Payments payments;
+
+    uint256 constant DEPOSIT_AMOUNT = 1000 ether;
+    uint256 constant RATE_ALLOWANCE = 100 ether;
+    uint256 constant LOCKUP_ALLOWANCE = 1000 ether;
+    uint256 constant MAX_LOCKUP_PERIOD = 100;
+    uint256 internal constant INITIAL_BALANCE = 1000 ether;
+
+    function setUp() public {
+        helper = new PaymentsTestHelpers();
+        helper.setupStandardTestEnvironment();
+        payments = helper.payments();
+
+        testToken = helper.testToken();
+    }
+
+    function testDepositWithAuthorization_HappyPath() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60;
+        uint256 amount = DEPOSIT_AMOUNT;
+
+        // Windows
+        uint256 validAfter = 0; // valid immediately
+        uint256 validBefore = block.timestamp + validForSeconds;
+
+        // Nonce: generate a unique bytes32 per authorization
+        // For tests you can make it deterministic:
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        // Pre-state capture
+        uint256 fromBalanceBefore = helper._balanceOf(from, false);
+        uint256 paymentsBalanceBefore = helper._balanceOf(address(payments), false);
+        Payments.Account memory toAccountBefore = helper._getAccountData(to, false);
+
+        // Build signature
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            fromPrivateKey,
+            address(testToken),
+            from,
+            address(payments), // pay to Payments contract which will credit 'to'
+            amount,
+            validAfter,
+            validBefore,
+            nonce
+        );
+
+        // Execute deposit via authorization
+        vm.startPrank(from);
+
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+
+        vm.stopPrank();
+
+        // Post-state capture
+        uint256 fromBalanceAfter = helper._balanceOf(from, false);
+        uint256 paymentsBalanceAfter = helper._balanceOf(address(payments), false);
+        Payments.Account memory toAccountAfter = helper._getAccountData(from, false);
+
+        // Assertions
+        helper._assertDepositBalances(
+            fromBalanceBefore,
+            fromBalanceAfter,
+            paymentsBalanceBefore,
+            paymentsBalanceAfter,
+            toAccountBefore,
+            toAccountAfter,
+            amount
+        );
+
+        // Verify authorization is consumed on the token
+        bool used = IERC3009(address(testToken)).authorizationState(from, nonce);
+        assertTrue(used);
+    }
+
+    function testDepositWithAuthorization_Revert_ReplayNonceUsed() public {
+        uint256 fromPrivateKey = user1Sk;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validForSeconds = 60;
+
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + validForSeconds;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            fromPrivateKey, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(from);
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        // Second attempt with same nonce must revert
+        vm.expectRevert("EIP3009: authorization already used");
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+    }
+
+    function testDepositWithAuthorization_Revert_InvalidSignature_WrongSigner() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 60;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        // Generate signature with a different private key
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user2Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(from);
+        vm.expectRevert("Invalid signature");
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+    }
+
+    function testDepositWithAuthorization_Revert_InvalidSignature_Corrupted() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 60;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        // Corrupt r
+        r = bytes32(uint256(r) ^ 1);
+
+        vm.startPrank(from);
+        vm.expectRevert("ECDSAInvalidSignature()"); // invalid signature should revert
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+    }
+
+    function testDepositWithAuthorization_Revert_ExpiredAuthorization() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 1;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        // advance beyond validBefore
+        vm.warp(validBefore + 1);
+
+        vm.startPrank(from);
+        vm.expectRevert("EIP3009: authorization expired"); // expired window should revert
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+    }
+
+    function testDepositWithAuthorization_Revert_NotYetValidAuthorization() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = block.timestamp + 60;
+        uint256 validBefore = validAfter + 300;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        // Pre-state capture
+        uint256 fromBalanceBefore = helper._balanceOf(from, false);
+        uint256 paymentsBalanceBefore = helper._balanceOf(address(payments), false);
+        Payments.Account memory toAccountBefore = helper._getAccountData(to, false);
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(from);
+        vm.expectRevert("EIP3009: authorization not yet valid"); // not yet valid
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+
+        // Now advance to validAfter + 1 and succeed
+        vm.warp(validAfter + 1);
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+
+        // Post-state capture
+        uint256 fromBalanceAfter = helper._balanceOf(from, false);
+        uint256 paymentsBalanceAfter = helper._balanceOf(address(payments), false);
+        Payments.Account memory toAccountAfter = helper._getAccountData(from, false);
+
+        // Assertions
+        helper._assertDepositBalances(
+            fromBalanceBefore,
+            fromBalanceAfter,
+            paymentsBalanceBefore,
+            paymentsBalanceAfter,
+            toAccountBefore,
+            toAccountAfter,
+            amount
+        );
+
+        // Verify authorization is consumed on the token
+        bool used = IERC3009(address(testToken)).authorizationState(from, nonce);
+        assertTrue(used);
+    }
+
+    function testDepositWithAuthorization_Revert_SubmittedByDifferentSender() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 300;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        // Attempt to submit as a different user
+        from = vm.addr(user2Sk);
+        vm.startPrank(from);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SignerMustBeMsgSender.selector, from, to));
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+    }
+
+    function testDepositWithAuthorization_Revert_InsufficientBalance() public {
+        helper.depositWithAuthorizationInsufficientBalance(user1Sk);
+    }
+
+    function testDepositWithAuthorization_Revert_DomainMismatchWrongToken() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 300;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        // Create a second token
+        MockERC20 otherToken = new MockERC20("OtherToken", "OTK");
+
+        // Sign against otherToken domain
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(otherToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(from);
+        vm.expectRevert("Invalid signature"); // domain mismatch
+        payments.depositWithAuthorization(address(testToken), to, amount, validAfter, validBefore, nonce, v, r, s);
+        vm.stopPrank();
+    }
+}

--- a/test/DepositWithAuthorizationAndOperatorApproval.t.sol
+++ b/test/DepositWithAuthorizationAndOperatorApproval.t.sol
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Payments, IERC3009} from "../src/Payments.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {PaymentsTestHelpers} from "./helpers/PaymentsTestHelpers.sol";
+import {BaseTestHelper} from "./helpers/BaseTestHelper.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {console} from "forge-std/console.sol";
+import {Errors} from "../src/Errors.sol";
+
+contract DepositWithAuthorization is Test, BaseTestHelper {
+    MockERC20 testToken;
+    PaymentsTestHelpers helper;
+    Payments payments;
+
+    uint256 constant DEPOSIT_AMOUNT = 1000 ether;
+    uint256 constant RATE_ALLOWANCE = 100 ether;
+    uint256 constant LOCKUP_ALLOWANCE = 1000 ether;
+    uint256 constant MAX_LOCKUP_PERIOD = 100;
+    uint256 internal constant INITIAL_BALANCE = 1000 ether;
+
+    function setUp() public {
+        helper = new PaymentsTestHelpers();
+        helper.setupStandardTestEnvironment();
+        payments = helper.payments();
+
+        testToken = helper.testToken();
+    }
+
+    function testDepositWithAuthorizationAndOperatorApproval_HappyPath() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60;
+        uint256 amount = DEPOSIT_AMOUNT;
+
+        helper.depositWithAuthorizationAndOperatorApproval(
+            fromPrivateKey, amount, validForSeconds, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+    }
+
+    function testDepositWithAuthorizationAndOperatorApproval_ZeroAmount() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60;
+        uint256 amount = 0; // Zero amount
+
+        helper.depositWithAuthorizationAndOperatorApproval(
+            fromPrivateKey, amount, validForSeconds, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+    }
+
+    function testDepositWithAuthorizationAndOperatorApproval_Revert_InvalidSignature() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 60;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        // Build signature with wrong private key
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user2Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(from);
+
+        vm.expectRevert("Invalid signature");
+        payments.depositWithAuthorizationAndApproveOperator(
+            address(testToken),
+            to,
+            amount,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            RATE_ALLOWANCE,
+            LOCKUP_ALLOWANCE,
+            MAX_LOCKUP_PERIOD
+        );
+
+        vm.stopPrank();
+    }
+
+    function testDepositWithAuthorizationAndOperatorApproval_Revert_InvalidSignature_Corrupted() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 60;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        // Corrupt r
+        r = bytes32(uint256(r) ^ 1);
+
+        vm.startPrank(from);
+        vm.expectRevert("ECDSAInvalidSignature()"); // invalid signature should revert
+        payments.depositWithAuthorizationAndApproveOperator(
+            address(testToken),
+            to,
+            amount,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            RATE_ALLOWANCE,
+            LOCKUP_ALLOWANCE,
+            MAX_LOCKUP_PERIOD
+        );
+    }
+
+    function testDepositWithAuthorizationAndOperatorApproval_Revert_ExpiredAuthorization() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = 0;
+        uint256 validBefore = block.timestamp + 1;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        // advance beyond validBefore
+        vm.warp(validBefore + 1);
+
+        vm.startPrank(from);
+        vm.expectRevert("EIP3009: authorization expired"); // expired window should revert
+        payments.depositWithAuthorizationAndApproveOperator(
+            address(testToken),
+            to,
+            amount,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            RATE_ALLOWANCE,
+            LOCKUP_ALLOWANCE,
+            MAX_LOCKUP_PERIOD
+        );
+    }
+
+    function testDepositWithAuthorizationAndOperatorApproval_Revert_NotYetValidAuthorization() public {
+        address from = vm.addr(user1Sk);
+        address to = from;
+        uint256 amount = DEPOSIT_AMOUNT;
+        uint256 validAfter = block.timestamp + 60;
+        uint256 validBefore = validAfter + 300;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, amount, block.number));
+
+        // Pre-state capture
+        uint256 fromBalanceBefore = helper._balanceOf(from, false);
+        uint256 paymentsBalanceBefore = helper._balanceOf(address(payments), false);
+        Payments.Account memory toAccountBefore = helper._getAccountData(to, false);
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), amount, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(from);
+        vm.expectRevert("EIP3009: authorization not yet valid"); // not yet valid
+        payments.depositWithAuthorizationAndApproveOperator(
+            address(testToken),
+            to,
+            amount,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            RATE_ALLOWANCE,
+            LOCKUP_ALLOWANCE,
+            MAX_LOCKUP_PERIOD
+        );
+    }
+
+    function testDepositWithAuthorizationAndIncreaseOperatorApproval_HappyPath() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60 * 60;
+        uint256 amount = DEPOSIT_AMOUNT;
+
+        // Step 1: First establish initial operator approval with deposit
+        helper.depositWithAuthorizationAndOperatorApproval(
+            fromPrivateKey, amount, validForSeconds, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+
+        // Step 2: Verify initial approval state
+        (bool isApproved, uint256 initialRateAllowance, uint256 initialLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(isApproved, true);
+        assertEq(initialRateAllowance, RATE_ALLOWANCE);
+        assertEq(initialLockupAllowance, LOCKUP_ALLOWANCE);
+
+        // Step 3: Prepare for the increase operation
+        uint256 additionalDeposit = 500 ether;
+        uint256 rateIncrease = 50 ether;
+        uint256 lockupIncrease = 500 ether;
+
+        // Give USER1 more tokens for the additional deposit
+        testToken.mint(USER1, additionalDeposit);
+
+        uint256 validAfter = 0;
+        uint256 validBefore = validAfter + validForSeconds;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, additionalDeposit, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), additionalDeposit, validAfter, validBefore, nonce
+        );
+
+        // Record initial account state
+        (uint256 initialFunds,,,) = payments.accounts(address(testToken), USER1);
+
+        // Step 4: Execute depositWithAuthorizationAndIncreaseOperatorApproval
+        vm.startPrank(USER1);
+        payments.depositWithAuthorizationAndIncreaseOperatorApproval(
+            address(testToken),
+            to,
+            additionalDeposit,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            rateIncrease,
+            lockupIncrease
+        );
+
+        vm.stopPrank();
+
+        // Step 5: Verify results
+        // Check deposit was successful
+        (uint256 finalFunds,,,) = payments.accounts(address(testToken), USER1);
+        assertEq(finalFunds, initialFunds + additionalDeposit);
+
+        // Check operator approval was increased
+        (, uint256 finalRateAllowance, uint256 finalLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(finalRateAllowance, initialRateAllowance + rateIncrease);
+        assertEq(finalLockupAllowance, initialLockupAllowance + lockupIncrease);
+    }
+
+    function testDepositWithAuthorizationAndIncreaseOperatorApproval_ZeroIncrease() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60 * 60;
+        uint256 amount = DEPOSIT_AMOUNT;
+
+        // Step 1: First establish initial operator approval with deposit
+        helper.depositWithAuthorizationAndOperatorApproval(
+            fromPrivateKey, amount, validForSeconds, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+
+        // Step 2: Verify initial approval state
+        (bool isApproved, uint256 initialRateAllowance, uint256 initialLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(isApproved, true);
+        assertEq(initialRateAllowance, RATE_ALLOWANCE);
+        assertEq(initialLockupAllowance, LOCKUP_ALLOWANCE);
+
+        // Step 3: Prepare for the increase operation
+        uint256 additionalDeposit = 500 ether;
+        uint256 rateIncrease = 0;
+        uint256 lockupIncrease = 0;
+
+        // Give USER1 more tokens for the additional deposit
+        testToken.mint(USER1, additionalDeposit);
+
+        uint256 validAfter = 0;
+        uint256 validBefore = validAfter + validForSeconds;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, additionalDeposit, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), additionalDeposit, validAfter, validBefore, nonce
+        );
+
+        // Record initial account state
+        (uint256 initialFunds,,,) = payments.accounts(address(testToken), USER1);
+
+        // Step 4: Execute depositWithAuthorizationAndIncreaseOperatorApproval
+        vm.startPrank(USER1);
+        payments.depositWithAuthorizationAndIncreaseOperatorApproval(
+            address(testToken),
+            to,
+            additionalDeposit,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            rateIncrease,
+            lockupIncrease
+        );
+
+        vm.stopPrank();
+
+        // Step 5: Verify results
+        // Check deposit was successful
+        (uint256 finalFunds,,,) = payments.accounts(address(testToken), USER1);
+        assertEq(finalFunds, initialFunds + additionalDeposit);
+
+        (, uint256 finalRateAllowance, uint256 finalLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(finalRateAllowance, initialRateAllowance); // No change
+        assertEq(finalLockupAllowance, initialLockupAllowance); // No change
+    }
+
+    function testDepositWithAuthorizationAndIncreaseOperatorApproval_InvalidSignature() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60 * 60;
+        uint256 amount = DEPOSIT_AMOUNT;
+
+        // First establish initial operator approval with deposit
+        helper.depositWithAuthorizationAndOperatorApproval(
+            fromPrivateKey, amount, validForSeconds, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+
+        // Verify initial approval state
+        (bool isApproved, uint256 initialRateAllowance, uint256 initialLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(isApproved, true);
+        assertEq(initialRateAllowance, RATE_ALLOWANCE);
+        assertEq(initialLockupAllowance, LOCKUP_ALLOWANCE);
+
+        // Prepare for the increase operation
+        uint256 additionalDeposit = 500 ether;
+        uint256 rateIncrease = 0;
+        uint256 lockupIncrease = 0;
+
+        // Give USER1 more tokens for the additional deposit
+        testToken.mint(USER1, additionalDeposit);
+
+        uint256 validAfter = 0;
+        uint256 validBefore = validAfter + validForSeconds;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, additionalDeposit, block.number));
+
+        // Create invalid permit signature (wrong private key)
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user2Sk, address(testToken), from, address(payments), additionalDeposit, validAfter, validBefore, nonce
+        );
+
+        vm.startPrank(USER1);
+        vm.expectRevert("Invalid signature");
+        payments.depositWithAuthorizationAndIncreaseOperatorApproval(
+            address(testToken),
+            to,
+            additionalDeposit,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            rateIncrease,
+            lockupIncrease
+        );
+        vm.stopPrank();
+
+        (, uint256 finalRateAllowance, uint256 finalLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(finalRateAllowance, initialRateAllowance); // No change
+        assertEq(finalLockupAllowance, initialLockupAllowance); // No change
+    }
+
+    function testDepositWithAuthorizationAndIncreaseOperatorApproval_WithExistingUsage() public {
+        uint256 fromPrivateKey = user1Sk;
+        address from = vm.addr(fromPrivateKey);
+        address to = from;
+        uint256 validForSeconds = 60 * 60;
+        uint256 amount = DEPOSIT_AMOUNT;
+
+        // First establish initial operator approval with deposit
+        helper.depositWithAuthorizationAndOperatorApproval(
+            fromPrivateKey, amount, validForSeconds, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+
+        // Create rail and use some allowance to establish existing usage
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0), SERVICE_FEE_RECIPIENT);
+        uint256 paymentRate = 30 ether;
+        uint256 lockupFixed = 200 ether;
+
+        vm.startPrank(OPERATOR);
+        payments.modifyRailPayment(railId, paymentRate, 0);
+        payments.modifyRailLockup(railId, 0, lockupFixed);
+        vm.stopPrank();
+
+        // Verify some allowance is used
+        (, uint256 preRateAllowance, uint256 preLockupAllowance, uint256 preRateUsage, uint256 preLockupUsage,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(preRateUsage, paymentRate);
+        assertEq(preLockupUsage, lockupFixed);
+
+        // Setup for additional deposit with increase
+        uint256 additionalDeposit = 500 ether;
+        uint256 rateIncrease = 70 ether;
+        uint256 lockupIncrease = 800 ether;
+
+        testToken.mint(USER1, additionalDeposit);
+
+        uint256 validAfter = 0;
+        uint256 validBefore = validAfter + validForSeconds;
+        bytes32 nonce = keccak256(abi.encodePacked("auth-nonce", from, to, additionalDeposit, block.number));
+
+        (uint8 v, bytes32 r, bytes32 s) = helper.getTransferWithAuthorizationSignature(
+            user1Sk, address(testToken), from, address(payments), additionalDeposit, validAfter, validBefore, nonce
+        );
+
+        (uint256 initialFunds,,,) = payments.accounts(address(testToken), USER1);
+
+        // Execute increase with existing usage
+        vm.startPrank(USER1);
+        payments.depositWithAuthorizationAndIncreaseOperatorApproval(
+            address(testToken),
+            to,
+            additionalDeposit,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s,
+            OPERATOR,
+            rateIncrease,
+            lockupIncrease
+        );
+        vm.stopPrank();
+
+        // Verify results
+        (uint256 finalFunds,,,) = payments.accounts(address(testToken), USER1);
+        assertEq(finalFunds, initialFunds + additionalDeposit);
+
+        (, uint256 finalRateAllowance, uint256 finalLockupAllowance, uint256 finalRateUsage, uint256 finalLockupUsage,)
+        = payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(finalRateAllowance, preRateAllowance + rateIncrease);
+        assertEq(finalLockupAllowance, preLockupAllowance + lockupIncrease);
+        assertEq(finalRateUsage, preRateUsage); // Usage unchanged
+        assertEq(finalLockupUsage, preLockupUsage); // Usage unchanged
+    }
+}

--- a/test/PaymentsEvents.t.sol
+++ b/test/PaymentsEvents.t.sol
@@ -309,7 +309,7 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
         // Only check the first three indexed parameters
         vm.expectEmit(true, true, true, true);
         emit Payments.AccountLockupSettled(address(testToken), USER2, 0, 0, block.number);
-        emit Payments.DepositRecorded(address(testToken), USER1, USER2, 10 ether, false); // Amount not checked
+        emit Payments.DepositRecorded(address(testToken), USER1, USER2, 10 ether, Payments.AuthType.None, bytes32(0)); // Amount not checked
 
         // Deposit tokens
         payments.deposit(address(testToken), USER2, 10 ether);
@@ -336,7 +336,9 @@ contract PaymentsEventsTest is Test, BaseTestHelper {
         // Expect the event to be emitted
         vm.expectEmit(true, true, false, true);
         emit Payments.AccountLockupSettled(address(testToken), signer, 0, 0, block.number);
-        emit Payments.DepositRecorded(address(testToken), signer, signer, depositAmount, true);
+        emit Payments.DepositRecorded(
+            address(testToken), signer, signer, depositAmount, Payments.AuthType.Permit, bytes32(0)
+        );
 
         // Deposit with permit
         payments.depositWithPermit(address(testToken), signer, depositAmount, deadline, v, r, s);

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -2,12 +2,74 @@
 pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
+/**
+ * @title MockERC20
+ * @dev A mock ERC20 token with permit (ERC-2612) and transferWithAuthorization (ERC-3009) functionality for testing purposes.
+ */
 contract MockERC20 is ERC20Permit {
+    // --- ERC-3009 State and Constants ---
+    mapping(address => mapping(bytes32 => bool)) private _authorizationStates;
+
+    bytes32 private constant _TRANSFER_WITH_AUTHORIZATION_TYPEHASH = keccak256(
+        "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+    );
+
+    // --- ERC-3009 Event ---
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
+
     constructor(string memory name, string memory symbol) ERC20(name, symbol) ERC20Permit(name) {}
 
     // Mint tokens for testing
     function mint(address to, uint256 amount) public {
         _mint(to, amount);
+    }
+
+    // --- ERC-3009 Implementation ---
+
+    /**
+     * @notice Execute a transfer with a signed authorization
+     * @param from          Payer's address (Authorizer)
+     * @param to            Payee's address
+     * @param value         Amount to be transferred
+     * @param validAfter    The time after which this is valid (unix time)
+     * @param validBefore   The time before which this is valid (unix time)
+     * @param nonce         Unique nonce
+     * @param v             v of the signature
+     * @param r             r of the signature
+     * @param s             s of the signature
+     */
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(block.timestamp > validAfter, "EIP3009: authorization not yet valid");
+        require(block.timestamp < validBefore, "EIP3009: authorization expired");
+        require(!_authorizationStates[from][nonce], "EIP3009: authorization already used");
+
+        bytes32 structHash = keccak256(
+            abi.encode(_TRANSFER_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)
+        );
+
+        bytes32 digest = EIP712._hashTypedDataV4(structHash);
+        address signer = ECDSA.recover(digest, v, r, s);
+        require(signer == from, "Invalid signature");
+
+        _authorizationStates[from][nonce] = true;
+        emit AuthorizationUsed(from, nonce);
+
+        _transfer(from, to, value);
+    }
+
+    function authorizationState(address authorizer, bytes32 nonce) external view returns (bool) {
+        return _authorizationStates[authorizer][nonce];
     }
 }


### PR DESCRIPTION
## Summary

Adds `ERC-3009` deposit flows, event extensions, and tests. 

## Changes

- Introduce `IERC3009`.
- Payments
    - Add `AuthType` enum; extend `DepositRecorded(token, from, to, amount, authType, nonce)`.
    - Generalize self-recipient check: `PermitRecipientMustBeMsgSender` → `SignerMustBeMsgSender`; `validatePermitRecipient` → `validateSignerIsRecipient`.
    - New methods: `depositWithAuthorization(...)`, `depositWithAuthorizationAndApproveOperator(...)`, `depositWithAuthorizationAndIncreaseOperatorApproval(...)`
- Tests
     - Comprehensive coverage for happy path, replay, signature errors, time windows, sender mismatch, insufficient balance, domain mismatch.
- Mock
     - `MockERC20`: implements ERC-3009. 

## Notes

- `authorizationState` used for replay protection
- `domain separation` enforced by signatures.