### PR TITLE
feat: allow relayers to submit deposit transactions

### DIFF
--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -285,4 +285,9 @@ library Errors {
     /// @param required The minimum required native token amount
     /// @param sent The amount of native token sent with the transaction
     error InsufficientNativeTokenForBurn(uint256 required, uint256 sent);
+
+    /// @notice The 'to' address in permit functions must be the message sender
+    /// @param expected The expected address (msg.sender)
+    /// @param actual The actual 'to' address provided
+    error PermitRecipientMustBeMsgSender(address expected, address actual);
 }

--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -285,9 +285,4 @@ library Errors {
     /// @param required The minimum required native token amount
     /// @param sent The amount of native token sent with the transaction
     error InsufficientNativeTokenForBurn(uint256 required, uint256 sent);
-
-    /// @notice The 'to' address in permit functions must be the message sender
-    /// @param expected The expected address (msg.sender)
-    /// @param actual The actual 'to' address provided
-    error PermitRecipientMustBeMsgSender(address expected, address actual);
 }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -489,12 +489,7 @@ contract Payments is ReentrancyGuard {
         uint8 v,
         bytes32 r,
         bytes32 s
-    )
-        external
-        nonReentrant
-        validateNonZeroAddress(to, "to")
-        settleAccountLockupBeforeAndAfter(token, to, false)
-    {
+    ) external nonReentrant validateNonZeroAddress(to, "to") settleAccountLockupBeforeAndAfter(token, to, false) {
         _depositWithPermit(token, to, amount, deadline, v, r, s);
     }
 

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -225,6 +225,11 @@ contract Payments is ReentrancyGuard {
         _;
     }
 
+    modifier validatePermitRecipient(address to) {
+        require(to == msg.sender, Errors.PermitRecipientMustBeMsgSender(msg.sender, to));
+        _;
+    }
+
     modifier settleAccountLockupBeforeAndAfter(address token, address owner, bool settleFull) {
         Account storage payer = accounts[token][owner];
 
@@ -558,6 +563,7 @@ contract Payments is ReentrancyGuard {
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
+        validatePermitRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _setOperatorApproval(token, operator, true, rateAllowance, lockupAllowance, maxLockupPeriod);
@@ -594,6 +600,7 @@ contract Payments is ReentrancyGuard {
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
+        validatePermitRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _increaseOperatorApproval(token, operator, rateAllowanceIncrease, lockupAllowanceIncrease);

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -225,11 +225,6 @@ contract Payments is ReentrancyGuard {
         _;
     }
 
-    modifier validatePermitRecipient(address to) {
-        require(to == msg.sender, Errors.PermitRecipientMustBeMsgSender(msg.sender, to));
-        _;
-    }
-
     modifier settleAccountLockupBeforeAndAfter(address token, address owner, bool settleFull) {
         Account storage payer = accounts[token][owner];
 
@@ -498,7 +493,6 @@ contract Payments is ReentrancyGuard {
         external
         nonReentrant
         validateNonZeroAddress(to, "to")
-        validatePermitRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _depositWithPermit(token, to, amount, deadline, v, r, s);
@@ -569,7 +563,6 @@ contract Payments is ReentrancyGuard {
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
-        validatePermitRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _setOperatorApproval(token, operator, true, rateAllowance, lockupAllowance, maxLockupPeriod);
@@ -606,7 +599,6 @@ contract Payments is ReentrancyGuard {
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
-        validatePermitRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _increaseOperatorApproval(token, operator, rateAllowanceIncrease, lockupAllowanceIncrease);

--- a/test/AccountManagement.t.sol
+++ b/test/AccountManagement.t.sol
@@ -70,8 +70,8 @@ contract AccountManagementTest is Test, BaseTestHelper {
         helper.expectInvalidPermitToRevert(user1Sk, USER1, DEPOSIT_AMOUNT);
     }
 
-    function testDepositWithPermitToAnotherUserReverts() public {
-        helper.expectDepositWithPermitToAnotherUserToRevert(user1Sk, USER2, DEPOSIT_AMOUNT);
+    function testDepositWithPermitToAnotherUser() public {
+        helper.makeDepositWithPermitToAnotherUser(user1Sk, RELAYER, DEPOSIT_AMOUNT);
     }
 
     function testNativeDepositWithInsufficientNativeTokens() public {

--- a/test/DepositWithPermitAndOperatorApproval.t.sol
+++ b/test/DepositWithPermitAndOperatorApproval.t.sol
@@ -65,12 +65,23 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
         uint256 deadline = block.timestamp + 1 hours;
 
         // get signature for permit
-        (uint8 v, bytes32 r, bytes32 s) = helper.getPermitSignature(user1Sk, from, address(payments), DEPOSIT_AMOUNT, deadline);
+        (uint8 v, bytes32 r, bytes32 s) =
+            helper.getPermitSignature(user1Sk, from, address(payments), DEPOSIT_AMOUNT, deadline);
 
         vm.startPrank(RELAYER);
         vm.expectRevert(abi.encodeWithSelector(Errors.PermitRecipientMustBeMsgSender.selector, RELAYER, from));
         payments.depositWithPermitAndApproveOperator(
-            address(testToken), from, DEPOSIT_AMOUNT, deadline, v, r, s, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+            address(testToken),
+            from,
+            DEPOSIT_AMOUNT,
+            deadline,
+            v,
+            r,
+            s,
+            OPERATOR,
+            RATE_ALLOWANCE,
+            LOCKUP_ALLOWANCE,
+            MAX_LOCKUP_PERIOD
         );
         vm.stopPrank();
     }
@@ -260,7 +271,7 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
 
     function testDepositWithPermitAndIncreaseOperatorApproval_Revert_DifferentSender() public {
         address from = USER1;
-        
+
         // Step 1: First establish initial operator approval with deposit
         helper.makeDepositWithPermitAndOperatorApproval(
             user1Sk, DEPOSIT_AMOUNT, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD

--- a/test/DepositWithPermitAndOperatorApproval.t.sol
+++ b/test/DepositWithPermitAndOperatorApproval.t.sol
@@ -59,6 +59,22 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
         );
     }
 
+    function testDepositWithPermitAndOperatorApproval_Revert_DifferentSender() public {
+        address from = USER1;
+        address to = from;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // get signature for permit
+        (uint8 v, bytes32 r, bytes32 s) = helper.getPermitSignature(user1Sk, from, address(payments), DEPOSIT_AMOUNT, deadline);
+
+        vm.startPrank(RELAYER);
+        vm.expectRevert(abi.encodeWithSelector(Errors.PermitRecipientMustBeMsgSender.selector, RELAYER, from));
+        payments.depositWithPermitAndApproveOperator(
+            address(testToken), from, DEPOSIT_AMOUNT, deadline, v, r, s, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+        vm.stopPrank();
+    }
+
     // SECTION: Deposit With Permit And Increase Operator Approval Tests
 
     function testDepositWithPermitAndIncreaseOperatorApproval_HappyPath() public {
@@ -240,5 +256,41 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
         assertEq(finalLockupAllowance, preLockupAllowance + lockupIncrease);
         assertEq(finalRateUsage, preRateUsage); // Usage unchanged
         assertEq(finalLockupUsage, preLockupUsage); // Usage unchanged
+    }
+
+    function testDepositWithPermitAndIncreaseOperatorApproval_Revert_DifferentSender() public {
+        address from = USER1;
+        
+        // Step 1: First establish initial operator approval with deposit
+        helper.makeDepositWithPermitAndOperatorApproval(
+            user1Sk, DEPOSIT_AMOUNT, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+
+        // Step 2: Verify initial approval state
+        (bool isApproved, uint256 initialRateAllowance, uint256 initialLockupAllowance,,,) =
+            payments.operatorApprovals(address(testToken), USER1, OPERATOR);
+        assertEq(isApproved, true);
+        assertEq(initialRateAllowance, RATE_ALLOWANCE);
+        assertEq(initialLockupAllowance, LOCKUP_ALLOWANCE);
+
+        // Step 3: Prepare for the increase operation
+        uint256 additionalDeposit = 500 ether;
+        uint256 rateIncrease = 50 ether;
+        uint256 lockupIncrease = 500 ether;
+
+        // Give USER1 more tokens for the additional deposit
+        testToken.mint(USER1, additionalDeposit);
+
+        // Get permit signature for the additional deposit
+        uint256 deadline = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) =
+            helper.getPermitSignature(user1Sk, USER1, address(payments), additionalDeposit, deadline);
+
+        vm.startPrank(RELAYER);
+        vm.expectRevert(abi.encodeWithSelector(Errors.PermitRecipientMustBeMsgSender.selector, RELAYER, from));
+        payments.depositWithPermitAndIncreaseOperatorApproval(
+            address(testToken), USER1, additionalDeposit, deadline, v, r, s, OPERATOR, rateIncrease, lockupIncrease
+        );
+        vm.stopPrank();
     }
 }

--- a/test/helpers/BaseTestHelper.sol
+++ b/test/helpers/BaseTestHelper.sol
@@ -11,6 +11,7 @@ contract BaseTestHelper is Test {
     uint256 internal operator2Sk = 5;
     uint256 internal validatorSk = 6;
     uint256 internal serviceFeeRecipientSk = 7;
+    uint256 internal relayerSk = 8;
 
     address public immutable OWNER = vm.addr(ownerSk);
     address public immutable USER1 = vm.addr(user1Sk);
@@ -19,4 +20,5 @@ contract BaseTestHelper is Test {
     address public immutable OPERATOR2 = vm.addr(operator2Sk);
     address public immutable VALIDATOR = vm.addr(validatorSk);
     address public immutable SERVICE_FEE_RECIPIENT = vm.addr(serviceFeeRecipientSk);
+    address public immutable RELAYER = vm.addr(relayerSk);
 }

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -837,16 +837,14 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         verifyOperatorAllowances(from, operator, false, 0, 0, 0, 0, 0); // No values should have been set due to revert - expect defaults
     }
 
-    function expectDepositWithPermitToAnotherUserToRevert(uint256 senderSk, address to, uint256 amount) public {
-        address from = vm.addr(senderSk);
+    function makeDepositWithPermitToAnotherUser(uint256 senderSk, address depositer, uint256 amount) public {
+        address to = vm.addr(senderSk);
         uint256 deadline = block.timestamp + 1 hours;
 
-        // Get permit signature for the sender
-        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(senderSk, from, address(payments), amount, deadline);
+        // Get permit signature for 'to' address
+        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(senderSk, to, address(payments), amount, deadline);
 
-        // Expect revert when trying to deposit to a different address than msg.sender
-        vm.startPrank(from);
-        vm.expectRevert(abi.encodeWithSelector(Errors.PermitRecipientMustBeMsgSender.selector, from, to));
+        vm.startPrank(depositer);
         payments.depositWithPermit(address(testToken), to, amount, deadline, v, r, s);
         vm.stopPrank();
     }


### PR DESCRIPTION
## Summary
This PR enables transaction relayers to submit deposit transactions on behalf of users by removing the restriction that the permit recipient must be the message sender.

## Changes

- Update `Payments` contract to allow relayers to submit permit signed by a user 
- Add tests

It'll improve UX by cutting down signatures from two to one as relayer / operators can accept permit and submit on users behalf.

Demo (deployment address: `0xa883569439A2E11482197d93526d64e598089DeD`):
1. Generate permit: https://eip2612.hashchainprotocol.com/generate-permit.html
2. Submit permit value + token address + signer address at https://eip2612.hashchainprotocol.com/

Closes #146 