### PR TITLE
fix(ci): remove npm ci from publish-abis workflow

### DIFF
--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install Dependencies
         run: |
           forge install
-          npm ci
       - name: Build & extract ABIs
         run: |
           make build


### PR DESCRIPTION
Similar to: https://github.com/FilOzone/pdp/pull/199. 

The publish-abis on releases workflow are failing (https://github.com/FilOzone/filecoin-pay/actions/runs/17854873063) because it tried to run `npm ci` on a Foundry project that doesn't have package.json at the root. We only need `forge install` for Solidity dependencies.