### PR TITLE
build: prep Filecoin-Pay 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,34 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
-- Support for ERC-3009 (Transfer with authorization) ([#214](https://github.com/FilOzone/filecoin-pay/pull/214))
-- Support for relayers to submit deposit transactions ([#217](https://github.com/FilOzone/filecoin-pay/pull/217))
-- Network fee charging in settlement operations ([#224](https://github.com/FilOzone/filecoin-pay/pull/224))
-- IERC20 type improvements and label mapping keys ([#225](https://github.com/FilOzone/filecoin-pay/pull/225))
 
 ### Changed
 
 ### Fixed
+
+## [0.6.0] - Filecoin-Pay M3
+
+### Deployed
+- **Calibration**: [TBD]()
+- **Mainnet**: [TBD]()
+
+### Added
+- Support for ERC-3009 (Transfer with authorization) ([#214](https://github.com/FilOzone/filecoin-pay/pull/214))
+- Support for relayers to submit deposit transactions ([#217](https://github.com/FilOzone/filecoin-pay/pull/217))
+- Network fee charging in settlement operations ([#224](https://github.com/FilOzone/filecoin-pay/pull/224))
+- IERC20 type improvements and label mapping keys ([#225](https://github.com/FilOzone/filecoin-pay/pull/225))
+- Fee auction functionality ([#229](https://github.com/FilOzone/filecoin-pay/pull/229))
+- feat: burn via precompile ([#234](https://github.com/FilOzone/filecoin-pay/pull/234))
+- Pagination support for `_getRailsForAddressAndToken` ([#237](https://github.com/FilOzone/filecoin-pay/pull/237))
+- feat!: Update auction starting price to 0.5 FIL ([#243](https://github.com/FilOzone/filecoin-pay/pull/243))
+
+### Changed
+- Restored settlement permissions allowing any participant to settle rails ([#221](https://github.com/FilOzone/filecoin-pay/pull/221))
+
+### Fixed
+- Network fee handling in `settleTerminatedRailWithoutValidation` ([#223](https://github.com/FilOzone/filecoin-pay/pull/223))
+- Add completed security audit report to readme ([#231](https://github.com/FilOzone/filecoin-pay/pull/231))
+
 
 ## [0.5.0] - Filecoin-Pay Developer Preview
 


### PR DESCRIPTION
Closes: https://github.com/FilOzone/filecoin-pay/issues/232

I used this: `git log f9b8844989185b50bad234039f8d8c4de8235665..HEAD --oneline --no-merges` (where the f9b88, is my best guess/estimate on which commit the previous contract on Calibration was published with based on the date posted in Slack). Changes called out in the changelog marked with ✅:

- a91f5e6 (HEAD -> phi/prep-M3-release, origin/phi/prep-M3-release) build: prep Filecoin-Pay 0.6.0 release
- ✅ f94ea2e (origin/main, origin/HEAD, main) feat: burn via precompile (#234)
- ✅ c6b12da feat!: Update auction starting price to 0.5 FIL (#243)
- ✅ 6a9c489 feat: add pagination to _getRailsForAddressAndToken (#237)
- ✅ 8313e55 revert: "revert: "Anyone Can settleRail (#219)"" (#221)
- ✅ a33b604 feat: Fee Auction (#229)
- 477228d forge lint (#240)
- b262e8f fix(ci): remove npm ci from publish-abis workflow (#236)
- 16a7923 (tag: v0.5.0) build: prep v0.5.0 version of Filecoin-Pay (#230)
- ✅ f990700 docs: add security audit to readme (#231)
- e50e8b1 feat: add changelog-file to filecoin-pay (#226)
- ✅ 3b298e4 IERC20 type, and label mapping keys (#225)
- ✅ 3fba762 chore: charge network fee in settleRailInternal (#224)
- ✅ 5a34645 feat: add support for ERC-3009 (#214)
- ✅ 29726a3 Fix lack of networkFee settleTerminatedRailWithoutValidation (#223)
- ✅ 2dcf206 revert: "Anyone Can settleRail (#219)" (#220)
- 7eb9650 Anyone Can settleRail (#219)
- ✅be3c91d feat: allow relayers to submit deposit transactions (#217)