### PR TITLE
build: Filecoin-Pay 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ All notable changes to this project will be documented in this file. The format 
 This major version bump signifies that FilecoinPay v1.0.0 is the long-term stable version intended for production use on Filecoin Mainnet. This release is specifically prepared for `M4: Filecoin Service Liftoff`.
 
 ### Deployed
-- **Calibration**: [TO_ADD_AFTER_DEPLOYMENT](https://calibration.filfox.info/en/address/)
-- **Mainnet**: [TO_ADD_AFTER_DEPLOYMENT](https://filfox.info/en/address/)
+- **Calibration**: [0x09a0fDc2723fAd1A7b8e3e00eE5DF73841df55a0](https://calibration.filfox.info/en/address/0x09a0fDc2723fAd1A7b8e3e00eE5DF73841df55a0)
+- **Mainnet**: [0x23b1e018F08BB982348b15a86ee926eEBf7F4DAa](https://filfox.info/en/address/0x23b1e018F08BB982348b15a86ee926eEBf7F4DAa)
 
 ### Added
 - Performance optimization: Fee apportionment now occurs after settling all segments instead of per segment ([#248](https://github.com/FilOzone/filecoin-pay/pull/248))


### PR DESCRIPTION
Publish Filecoin-Pay v1.0.0 release for M4:

_Diff from the v0.6.0 tag:_
```
git log v0.6.0..HEAD --oneline --no-merges 
a0e7f88 (HEAD -> phi/prep-v1.0.0-release, origin/main, origin/HEAD, main) perf: Apportion fees after settling segments instead of per segment (#248)
2f0dd1c feat: implement contract versioning for FilecoinPay (#247)
d3e5dd1 chore: update auction start price to 0.0021 (#245)
```

All three changes since the v0.6.0 release have been called out in the changelog.