### PR TITLE
fix(RateChangeQueue): remove unreachable array clearing logic

### DIFF
--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -23,16 +23,7 @@ library RateChangeQueue {
         require(queue.head < c.length, "Queue is empty");
         RateChange memory change = c[queue.head];
         delete c[queue.head];
-
-        if (isEmpty(queue)) {
-            queue.head = 0;
-            // The array is already empty, waste no time zeroing it.
-            assembly {
-                sstore(c.slot, 0)
-            }
-        } else {
-            queue.head++;
-        }
+        queue.head++;
 
         return change;
     }


### PR DESCRIPTION
Closes #266.  I went with the solution removing clearing array size entirely as this is minutely more efficient.