### PR TITLE
fix(settlement): accumulate validator notes across rate change segments

### DIFF
--- a/src/FilecoinPayV1.sol
+++ b/src/FilecoinPayV1.sol
@@ -1361,7 +1361,15 @@ contract FilecoinPayV1 is ReentrancyGuard {
 
             // Add the gross settled amount to our running total
             totalGrossSettled += segmentGrossSettled;
-            note = validationNote;
+
+            // Accumulate validation notes from each segment
+            if (bytes(validationNote).length > 0) {
+                if (bytes(note).length > 0) {
+                    note = string.concat(note, "; ", validationNote);
+                } else {
+                    note = validationNote;
+                }
+            }
 
             // If validator partially settled the segment, exit early
             if (rail.settledUpTo < segmentEndBoundary) {

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -226,8 +226,13 @@ contract RailSettlementTest is Test, BaseTestHelper {
         RailSettlementHelpers.SettlementResult memory result =
             settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, block.number);
 
-        // Verify validator note
-        assertEq(result.note, "Standard approved payment", "Validator note should match");
+        // Verify validator notes are accumulated from all 9 segments
+        // (8 rate changes in the queue + 1 final segment)
+        string memory expectedNote = "Standard approved payment";
+        for (uint256 i = 1; i < 9; i++) {
+            expectedNote = string.concat(expectedNote, "; Standard approved payment");
+        }
+        assertEq(result.note, expectedNote, "Validator notes should be accumulated");
     }
 
     function testValidationWithReducedAmount() public {


### PR DESCRIPTION
Closes #268 

I went with the append option.  I think this is fine as non empty notes only show up as error conditions in our only existing validator and as auditors have pointed out settling many segments will cost linearly increasing gas so this is only adding a constant term to an existing efficiency problem not creating a whole new problem.  And it is a simple matter for users to settle smaller spans of time if we actually start hitting gas problems.