### PR TITLE
fix(RateChangeQueue): empty queue behavior

### DIFF
--- a/src/FilecoinPayV1.sol
+++ b/src/FilecoinPayV1.sol
@@ -1596,6 +1596,7 @@ contract FilecoinPayV1 is ReentrancyGuard {
         rail.settledUpTo = 0;
         rail.endEpoch = 0;
         rail.commissionRateBps = 0;
+        rail.rateChangeQueue.clearEmpty();
     }
 
     function updateOperatorRateUsage(OperatorApproval storage approval, uint256 oldRate, uint256 newRate) internal {

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -31,6 +31,7 @@ library RateChangeQueue {
 
     // Clears the storage of the Queue
     // If the queue isEmpty, all queue storage will be cleared
+    // Otherwise, the queue is functionally emptied but pending RateChange are not cleared from storage
     function clearEmpty(Queue storage queue) internal {
         queue.head = 0;
         RateChange[] storage c = queue.changes;

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -39,7 +39,6 @@ library RateChangeQueue {
         }
     }
 
-
     function peek(Queue storage queue) internal view returns (RateChange memory change) {
         require(queue.head < queue.changes.length, EmptyQueue());
         unchecked {

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -37,8 +37,6 @@ library RateChangeQueue {
         } else {
             queue.head++;
         }
-
-        return change;
     }
 
     function peek(Queue storage queue) internal view returns (RateChange memory change) {

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -25,19 +25,20 @@ library RateChangeQueue {
         require(queue.head < c.length, EmptyQueue());
         unchecked {
             change = c[queue.head];
-            delete c[queue.head];
-        }
-
-        if (queue.head + 1 == c.length) {
-            queue.head = 0;
-            // The array is already empty, waste no time zeroing it.
-            assembly {
-                sstore(c.slot, 0)
-            }
-        } else {
-            queue.head++;
+            delete c[queue.head++];
         }
     }
+
+    // Clears the storage of the Queue
+    // If the queue isEmpty, all queue storage will be cleared
+    function clearEmpty(Queue storage queue) internal {
+        queue.head = 0;
+        RateChange[] storage c = queue.changes;
+        assembly ("memory-safe") {
+            sstore(c.slot, 0)
+        }
+    }
+
 
     function peek(Queue storage queue) internal view returns (RateChange memory change) {
         require(queue.head < queue.changes.length, EmptyQueue());

--- a/test/RateChangeQueue.t.sol
+++ b/test/RateChangeQueue.t.sol
@@ -117,6 +117,9 @@ contract RateChangeQueueTest is Test {
         // Queue should now be empty
         assertTrue(RateChangeQueue.isEmpty(queue()));
         assertEq(RateChangeQueue.size(queue()), 0);
+
+        // Empty queue should have reset to head = 0
+        assertEq(queue().head, 0);
     }
 
     /// forge-config: default.allow_internal_expect_revert = true
@@ -124,7 +127,7 @@ contract RateChangeQueueTest is Test {
         createEmptyQueue();
 
         // Test dequeue on empty queue
-        vm.expectRevert("Queue is empty");
+        vm.expectRevert(abi.encodeWithSelector(RateChangeQueue.EmptyQueue.selector));
         RateChangeQueue.dequeue(queue());
     }
 
@@ -133,7 +136,7 @@ contract RateChangeQueueTest is Test {
         createEmptyQueue();
 
         // Test peek on empty queue
-        vm.expectRevert("Queue is empty");
+        vm.expectRevert(abi.encodeWithSelector(RateChangeQueue.EmptyQueue.selector));
         RateChangeQueue.peek(queue());
     }
 
@@ -142,7 +145,7 @@ contract RateChangeQueueTest is Test {
         createEmptyQueue();
 
         // Test peekTail on empty queue
-        vm.expectRevert("Queue is empty");
+        vm.expectRevert(abi.encodeWithSelector(RateChangeQueue.EmptyQueue.selector));
         RateChangeQueue.peekTail(queue());
     }
 

--- a/test/RateChangeQueue.t.sol
+++ b/test/RateChangeQueue.t.sol
@@ -119,7 +119,9 @@ contract RateChangeQueueTest is Test {
         assertEq(RateChangeQueue.size(queue()), 0);
 
         // Empty queue should have reset to head = 0
+        queue().clearEmpty();
         assertEq(queue().head, 0);
+        assertEq(queue().changes.length, 0);
     }
 
     /// forge-config: default.allow_internal_expect_revert = true


### PR DESCRIPTION
Fixes #266
Reviewer @zenground0
#### Changes
* move reset of head = 0 to when zeroing rail
* change string revert error 'Queue is empty' into abi 'error EmptyQueue()' 
* remove redundant bounds checking with `unchecked`