### PR TITLE
chore(ci): stable Foundry

### DIFF
--- a/.github/workflows/contract-size.yml
+++ b/.github/workflows/contract-size.yml
@@ -18,6 +18,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v1.3.5
+          cache: true
       
       - name: Install Dependencies
         run: forge install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.5
           cache: true
 
       - name: Cache dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v1.3.5
+          cache: true
 
       - name: fmt
         run: |

--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.5
+          cache: true
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v1.3.5
+          cache: true
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION

Reviewer @zenground0
This PR is trying to address some CI failures.
Seems `nightly` is broken so we should pin instead.
But there might be a reason we were using nightly.
I'll keep iterating on this until it passes.