### PR TITLE
chore: fix unwrapped modifier linting and optimize deployment size

### DIFF
--- a/src/FilecoinPayV1.sol
+++ b/src/FilecoinPayV1.sol
@@ -1577,9 +1577,10 @@ contract FilecoinPayV1 is ReentrancyGuard {
     }
 
     function _onlyRailOperator(uint256 railId) internal view {
-        require(
-            rails[railId].operator == msg.sender, Errors.OnlyRailOperatorAllowed(rails[railId].operator, msg.sender)
-        );
+        address operator = rails[railId].operator;
+        if (operator != msg.sender) {
+            revert Errors.OnlyRailOperatorAllowed(operator, msg.sender);
+        }
     }
 
     function _validateRailTerminated(uint256 railId) internal view {

--- a/src/FilecoinPayV1.sol
+++ b/src/FilecoinPayV1.sol
@@ -210,7 +210,7 @@ contract FilecoinPayV1 is ReentrancyGuard {
     }
 
     modifier validateRailActive(uint256 railId) {
-        require(rails[railId].from != address(0), Errors.RailInactiveOrSettled(railId));
+        _validateRailActive(railId);
         _;
     }
 
@@ -220,9 +220,7 @@ contract FilecoinPayV1 is ReentrancyGuard {
     }
 
     modifier onlyRailOperator(uint256 railId) {
-        require(
-            rails[railId].operator == msg.sender, Errors.OnlyRailOperatorAllowed(rails[railId].operator, msg.sender)
-        );
+        _onlyRailOperator(railId);
         _;
     }
 
@@ -232,17 +230,17 @@ contract FilecoinPayV1 is ReentrancyGuard {
     }
 
     modifier validateRailTerminated(uint256 railId) {
-        require(isRailTerminated(rails[railId], railId), Errors.RailNotTerminated(railId));
+        _validateRailTerminated(railId);
         _;
     }
 
     modifier validateNonZeroAddress(address addr, string memory varName) {
-        require(addr != address(0), Errors.ZeroAddressNotAllowed(varName));
+        _validateNonZeroAddress(addr, varName);
         _;
     }
 
     modifier validateSignerIsRecipient(address to) {
-        require(to == msg.sender, Errors.SignerMustBeMsgSender(msg.sender, to));
+        _validateSignerIsRecipient(to);
         _;
     }
 
@@ -1572,6 +1570,28 @@ contract FilecoinPayV1 is ReentrancyGuard {
     function isRailTerminated(Rail storage rail, uint256 railId) internal view returns (bool) {
         require(rail.from != address(0), Errors.RailInactiveOrSettled(railId));
         return rail.endEpoch > 0;
+    }
+
+    function _validateRailActive(uint256 railId) internal view {
+        require(rails[railId].from != address(0), Errors.RailInactiveOrSettled(railId));
+    }
+
+    function _onlyRailOperator(uint256 railId) internal view {
+        require(
+            rails[railId].operator == msg.sender, Errors.OnlyRailOperatorAllowed(rails[railId].operator, msg.sender)
+        );
+    }
+
+    function _validateRailTerminated(uint256 railId) internal view {
+        require(isRailTerminated(rails[railId], railId), Errors.RailNotTerminated(railId));
+    }
+
+    function _validateNonZeroAddress(address addr, string memory varName) internal pure {
+        require(addr != address(0), Errors.ZeroAddressNotAllowed(varName));
+    }
+
+    function _validateSignerIsRecipient(address to) internal view {
+        require(to == msg.sender, Errors.SignerMustBeMsgSender(msg.sender, to));
     }
 
     // Get the final settlement epoch for a terminated rail


### PR DESCRIPTION
## Summary

Extracted the `require` logic from the 5 most-used modifiers into dedicated `internal` helper functions, following the pattern already used by `performSettlementCheck`.

Modifiers wrapped: `validateNonZeroAddress`, `validateRailActive`, `validateRailTerminated`, `validateSignerIsRecipient`, `onlyRailOperator`

Intentionally left alone: `onlyRailClient`, `validateRailNotTerminated` (used once each and wrapping would increase bytecode), and the `settleAccountLockup*` modifiers (already delegate to `performSettlementCheck`).

## Size impact

| Metric | Before | After | Δ |
|---|---|---|---|
| Runtime Size | 20,849 B | 20,527 B | **-322 B** |
| Runtime Margin | 3,727 B | 4,049 B | **+322 B** |

## Note

I realize `V1` is already live on mainnet, so this won't impact current deployments. I'm submitting this purely as a codebase health update to clear linting warnings, free up contract size headroom for future features, and establish efficient patterns for V2.